### PR TITLE
Region Options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 __pycache__
+.vscode

--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ Here's a list of frequently asked questions.
 ```
 Q: Why does it show that my alt has completed an achievement?
 A: Some achievements are account wide so the API response for your alt will be the same as your main.
+
+Q: Do you plan on supporting Mythic+ scores?
+A: Only if the official Blizzard API begins supporting their own metric.
 ```
 
-## Issues and Feedback
-Please post any issues or feedback [here](https://github.com/JamesIves/discord-wow-armory-bot/issues).
+## Issues, Feedback and Feature Requests
+Please post any issues, feedback, or feature requests [here](https://github.com/JamesIves/discord-wow-armory-bot/issues).
 
 
 ![Screenshot](assets/screenshot.png)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In order to power this bot you'll require a [Discord API bot token]((https://dis
 | `LOCALE`  | The language for your selected WoW region, for example `en_US`, or `en_GB`. Locale depends on region, please refer to the [Blizzard API documents](https://dev.battle.net/) for more information. At this time this bot will only return data in English.   |
 | `DISCORD_BOT_TOKEN`  | The token for your Discord bot user, you can sign up for one [here](https://discordapp.com/developers/docs/intro). |
 
-Once you've configured the variables you may need to restart the service.
+Once you've configured the variables you may need to restart the service. If a variable is missing the terminal you executed the bot from will display an error message.
 
 
 ## Inviting the Bot
@@ -63,6 +63,10 @@ The following commands are accepted by the bot.
 # Displays a players PVP progression, arena ratings, honorable kills, etc.
 !armory pvp <name> <realm>
 !armory pvp <armory-link>
+
+# You can also provide an optional region to each query to display players from other WoW regions outside of the bot default, for example EU, US, etc.
+!armory pve <name> <realm> <region>
+!armory pvp <armory-link> <region>
 
 # Command list/help
 !armory help

--- a/app.py
+++ b/app.py
@@ -229,7 +229,7 @@ async def on_ready():
         print('Missing Discord bot token. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
 
     else:
-        print('Launch Succesful!')
+        print('Launch Succesful! The bot is now listening for commands...')
 
 
 client.run(DISCORD_BOT_TOKEN)

--- a/app.py
+++ b/app.py
@@ -1,20 +1,20 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-import discord
 import os
+import discord
 import re
 import time
 from wow import *
 from util import *
+from settings import *
 
-# Discord API values
-DISCORD_BOT_TOKEN = str(os.environ.get('DISCORD_BOT_TOKEN'))
+
 client = discord.Client()
 
 @client.event
 async def on_message(message):
     """Listens for specific user messages."""
-    bot_error = 'Could not find a player with that name/realm combination. Type `!armory help` for more a list of valid commands.'
+    bot_error = 'Could not find a player with that name, realm or region combination. Type `!armory help` for more a list of valid commands.'
 
     # If the author is the bot do nothing.
     if message.author == client.user:
@@ -24,10 +24,14 @@ async def on_message(message):
     if message.content.startswith('!armory pve'):
         # Sends the query to be split via a utility function. Accepts either a character/realm, or an armory link.
         split = split_query(message.content, 'pve')
-        # Sends the returned data to the character_info function to build a character sheet.
-        info = character_info(split[0], split[1], split[2])
 
-        # If the returned data is an empty string send a message saying the player/realm couldn't be found.
+        # Assigns the 3rd index in the split to the region
+        region = split[3]
+
+        # Sends the returned data to the character_info function to build a character sheet.
+        info = character_info(split[0], split[1], split[2], region)
+
+        # If the returned data is an empty string send a message saying the player/realm/region couldn't be found.
         if info == '':
             msg = bot_error.format(message)
             await client.send_message(message.channel, msg)
@@ -63,14 +67,14 @@ async def on_message(message):
                     info['level'], info['faction'], info['spec'], info['class_type']))
             msg.set_thumbnail(
                 url="https://render-%s.worldofwarcraft.com/character/%s?_%s" % (
-                    WOW_REGION, info['thumb'], epoch_time))
+                    region, info['thumb'], epoch_time))
             msg.set_footer(
                 text="!armory help | Feedback: https://github.com/JamesIves/discord-wow-armory-bot/issues",
                 icon_url="https://raw.githubusercontent.com/JamesIves/discord-wow-armory-bot/master/assets/icon.png")
             msg.add_field(
                 name="Character",
-                value="**`Name`:** `%s`\n**`Realm`:** `%s`\n**`Item Level`:** `%s`\n**`Artifact Challenge`:** `%s`" % (
-                    info['name'], info['realm'], info['ilvl'], info['challenging_look']),
+                value="**`Name`:** `%s`\n**`Realm`:** `%s (%s)`\n**`Item Level`:** `%s`\n**`Artifact Challenge`:** `%s`" % (
+                    info['name'], info['realm'], region.upper(), info['ilvl'], info['challenging_look']),
                 inline=True)
             msg.add_field(
                 name="Keystone Achievements",
@@ -117,7 +121,8 @@ async def on_message(message):
     # Same as before, except this time it's building data for PVP.
     if message.content.startswith('!armory pvp'):
         split = split_query(message.content, 'pvp')
-        info = character_info(split[0], split[1], split[2])
+        region = split[3]
+        info = character_info(split[0], split[1], split[2], split[3])
 
         if info == '':
             msg = bot_error.format(message)
@@ -133,14 +138,14 @@ async def on_message(message):
                     info['level'], info['faction'], info['spec'], info['class_type']))
             msg.set_thumbnail(
                 url="https://render-%s.worldofwarcraft.com/character/%s" % (
-                    WOW_REGION, info['thumb']))
+                    region, info['thumb']))
             msg.set_footer(
                 text="!armory help | Feedback: https://github.com/JamesIves/discord-wow-armory-bot/issues",
                 icon_url="https://github.com/JamesIves/discord-wow-armory-bot/blob/master/assets/icon.png?raw=true")
             msg.add_field(
                 name="Character",
-                value="**`Name`:** `%s`\n**`Realm`:** `%s`\n**`Battlegroup`:** `%s`\n**`Item Level`:** `%s`" % (
-                    info['name'], info['realm'], info['battlegroup'], info['ilvl']),
+                value="**`Name`:** `%s`\n**`Realm`:** `%s (%s)`\n**`Battlegroup`:** `%s`\n**`Item Level`:** `%s`" % (
+                    info['name'], info['realm'], region.upper(), info['battlegroup'], info['ilvl']),
                 inline=True)
             msg.add_field(
                 name="Arena Achievements",
@@ -196,6 +201,10 @@ async def on_message(message):
             !armory pvp <name> <realm>
             !armory pvp <armory-link>
 
+            # You can also provide an optional region to each query to display players from other WoW regions outside of the bot default, for example EU, US, etc.
+            !armory pve <name> <realm> <region>
+            !armory pvp <armory-link> <region>
+
             ```
             • Bot created by James Ives (jamesives.co.uk)
             • Feedback, Issues and Source: https://github.com/JamesIves/discord-wow-armory-bot/issues
@@ -203,6 +212,24 @@ async def on_message(message):
 
         msg = '%s'.format(message) % re.sub(r'(^[ \t]+|[ \t]+(?=:))', '', msg, flags=re.M)
         await client.send_message(message.channel, msg)
+
+
+@client.event
+async def on_ready():
+    if WOW_API_KEY == '':
+        quit('Missing World of Warcraft API key. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
+
+    if WOW_REGION == '':
+        quit('Missing World of Warcraft player region. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
+
+    if LOCALE == '':
+        quit('Missing locale. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
+
+    if DISCORD_BOT_TOKEN == '':
+        quit('Missing Discord bot token. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
+
+    else:
+        print('Launch Succesful!')
 
 
 client.run(DISCORD_BOT_TOKEN)

--- a/app.py
+++ b/app.py
@@ -217,16 +217,16 @@ async def on_message(message):
 @client.event
 async def on_ready():
     if WOW_API_KEY == '':
-        quit('Missing World of Warcraft API key. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
+        print('Missing World of Warcraft API key. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
 
     if WOW_REGION == '':
-        quit('Missing World of Warcraft player region. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
+        print('Missing World of Warcraft player region. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
 
     if LOCALE == '':
-        quit('Missing locale. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
+        print('Missing locale. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
 
     if DISCORD_BOT_TOKEN == '':
-        quit('Missing Discord bot token. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
+        print('Missing Discord bot token. Please refer to https://github.com/JamesIves/discord-wow-armory-bot#configuration for more details')
 
     else:
         print('Launch Succesful!')

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+import os
+
+"""Application settings such as API keys are stored here."""
+
+# World of Warcraft API Settings
+WOW_API_KEY = str(os.environ.get('WOW_API_KEY'))
+WOW_REGION = str(os.environ.get('WOW_REGION'))
+LOCALE = str(os.environ.get('LOCALE'))
+
+# Discord API Settings
+DISCORD_BOT_TOKEN = str(os.environ.get('DISCORD_BOT_TOKEN'))

--- a/tests.py
+++ b/tests.py
@@ -7,7 +7,7 @@ class BaseTest(unittest.TestCase):
 
     def test_for_normal_query_split(self):
         # Tests to ensure that the query gets split properly when the bot gets a message.
-        # Example query: '!armory pve/pvp <name> <realm>'
+        # Example query: '!armory pve/pvp <name> <realm> <region>'
         sample_query = '!armory pve jimo burning-legion us'
 
         self.assertEqual(split_query(sample_query, 'pve'), ['jimo', 'burning-legion', 'pve', 'us'])
@@ -15,7 +15,7 @@ class BaseTest(unittest.TestCase):
 
     def test_for_url_query_split(self):
         # Tests to ensure that the query string gets split properly when the bot gets a url based message.
-        # Example query: '!armory pve/pvp <armory-link>' (Accepts either a world of warcraft or battle net link)
+        # Example query: '!armory pve/pvp <armory-link> <region>' (Accepts either a world of warcraft or battle net link)
         sample_wow_url = '!armory pve https://worldofwarcraft.com/en-us/character/burning-legion/jimo us'
         sample_battlenet_url = '!armory pve http://us.battle.net/wow/en/character/burning-legion/jimo/advanced us'
 

--- a/tests.py
+++ b/tests.py
@@ -8,19 +8,19 @@ class BaseTest(unittest.TestCase):
     def test_for_normal_query_split(self):
         # Tests to ensure that the query gets split properly when the bot gets a message.
         # Example query: '!armory pve/pvp <name> <realm>'
-        sample_query = '!armory pve jimo burning-legion'
+        sample_query = '!armory pve jimo burning-legion us'
 
-        self.assertEqual(split_query(sample_query, 'pve'), ['jimo', 'burning-legion', 'pve'])
+        self.assertEqual(split_query(sample_query, 'pve'), ['jimo', 'burning-legion', 'pve', 'us'])
 
 
     def test_for_url_query_split(self):
         # Tests to ensure that the query string gets split properly when the bot gets a url based message.
         # Example query: '!armory pve/pvp <armory-link>' (Accepts either a world of warcraft or battle net link)
-        sample_wow_url = 'https://worldofwarcraft.com/en-us/character/burning-legion/jimo'
-        sample_battlenet_url = 'http://us.battle.net/wow/en/character/burning-legion/jimo/advanced'
+        sample_wow_url = '!armory pve https://worldofwarcraft.com/en-us/character/burning-legion/jimo us'
+        sample_battlenet_url = '!armory pve http://us.battle.net/wow/en/character/burning-legion/jimo/advanced us'
 
-        self.assertEqual(split_query(sample_wow_url, 'pve'), ['jimo', 'burning-legion', 'pve'])
-        self.assertEqual(split_query(sample_battlenet_url, 'pvp'), ['jimo', 'burning-legion', 'pvp'])
+        self.assertEqual(split_query(sample_wow_url, 'pve'), ['jimo', 'burning-legion', 'pve', 'us'])
+        self.assertEqual(split_query(sample_battlenet_url, 'pvp'), ['jimo', 'burning-legion', 'pvp', 'us'])
 
 
     def test_for_warrior_class(self):

--- a/util.py
+++ b/util.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 import re
+from settings import WOW_REGION
 
 def split_query(message, content):
     """Helper function that splits a string and returns data
@@ -10,10 +11,20 @@ def split_query(message, content):
     # it splits the string starting at 'character/'
     if 'worldofwarcraft' in message or 'battle.net' in message:
         url = re.split('\\bcharacter/\\b', message)[-1]
-        split = url.split('/')
-        return [split[1], split[0], content]
+        split = url.split(' ', 1)[0].split('/')
+        message = message.split(' ')
+
+        # Check if a region was provided, otherwise use the region setting.
+        try:
+            return [split[1], split[0], content, message[3]]
+        except IndexError:
+            return [split[1], split[0], content, WOW_REGION]
 
     # Assumes it's not a url path, and splits the string normally.
     else:
         split = message.split(' ')
-        return [split[2], split[3], content]
+
+        try:
+            return [split[2], split[3], content, split[4]]
+        except IndexError:
+            return [split[2], split[3], content, WOW_REGION]

--- a/wow.py
+++ b/wow.py
@@ -1,19 +1,14 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 import requests
-import json
-import os
+from settings import WOW_API_KEY, LOCALE
 from constants import *
 
-# Blizzard API values
-WOW_API_KEY = str(os.environ.get('WOW_API_KEY'))
-WOW_REGION = str(os.environ.get('WOW_REGION'))
-LOCALE = str(os.environ.get('LOCALE'))
 
-def get_data(name, realm, field):
+def get_data(name, realm, field, region):
     """Helper function that grabs data from the World of Warcraft API."""
     path = 'https://%s.api.battle.net/wow/character/%s/%s?fields=%s&locale=%s&apikey=%s' % (
-        WOW_REGION, realm, name, field, LOCALE, WOW_API_KEY)
+        region, realm, name, field, LOCALE, WOW_API_KEY)
 
     try:
         request = requests.get(path)
@@ -352,15 +347,13 @@ def class_details(class_type):
     return class_data
 
 
-def character_info(name, realm, query):
+def character_info(name, realm, query, region):
     """Main function which accepts a name/realm/query(pvp or pve).
     Builds a character sheet out of their name, realm,
     armory link, player thumbnail, ilvl, achievement and raid progress and more."""
-    name = name
-    realm = realm
 
     # Grabs overall character data including their ilvl.
-    info = get_data(name, realm, 'items')
+    info = get_data(name, realm, 'items', region)
 
     # If the data returned isn't an empty string assume it found a character.
     if info != '':
@@ -368,16 +361,16 @@ def character_info(name, realm, query):
         faction_name = faction_details(info['faction'])
 
         # Gathers achievement data from the achievements API.
-        achievement_data = get_data(name, realm, 'achievements')
+        achievement_data = get_data(name, realm, 'achievements', region)
         achievements = character_achievements(achievement_data, faction_name)
 
         # Gathers talent data
-        talent_data = get_data(name, realm, 'talents')
+        talent_data = get_data(name, realm, 'talents', region)
         talents = character_talents(talent_data)
 
         # Builds a character sheet depending on the function argument.
         if query == 'pve':
-            progression_data = get_data(name, realm, 'progression')
+            progression_data = get_data(name, realm, 'progression', region)
             progression = character_progression(progression_data)
 
             pve_character_sheet = {
@@ -390,7 +383,7 @@ def character_info(name, realm, query):
                 'class_colour': class_data['colour'],
                 'class_type': class_data['name'],
                 'armory': 'http://%s.battle.net/wow/en/character/%s/%s' % (
-                    WOW_REGION, realm, name),
+                   region, realm, name),
                 'thumb': info['thumbnail'],
                 'ilvl': info['items']['averageItemLevelEquipped'],
                 'challenging_look': achievements['challenging_look'],
@@ -410,7 +403,7 @@ def character_info(name, realm, query):
             return pve_character_sheet
 
         if query == 'pvp':
-            pvp_data = get_data(name, realm, 'pvp')
+            pvp_data = get_data(name, realm, 'pvp', region)
             pvp = character_arena_progress(pvp_data)
 
             pvp_character_sheet = {
@@ -423,7 +416,7 @@ def character_info(name, realm, query):
                 'class_colour': class_data['colour'],
                 'class_type': class_data['name'],
                 'armory': 'http://%s.battle.net/wow/en/character/%s/%s' % (
-                    WOW_REGION, realm, name),
+                    region, realm, name),
                 'thumb': info['thumbnail'],
                 'ilvl': info['items']['averageItemLevelEquipped'],
                 'arena_challenger': achievements['arena_challenger'],


### PR DESCRIPTION
Added the ability to pass a WoW player region into the query. This allows players to query a player from the EU region if the US one is specified in the Config Vars. If one is not provided it falls back to the default. I have updated the unit tests to handle this use case. So far this has been tested on the `eu`, `us` and `kr` realms without issue. I also added the region next to the realm part of Discord message, for example `Burning Legion (US)`. 

I've also added some error handling incase a configuration variable is missing, it will now exit the application and log the reason to the terminal window.

Also moved all configuration options into a settings.py file and removed a few unneeded declarations. 

This PR resolves #24 