### PR TITLE
Battle of Dazar'alor Raid Data

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ async def on_message(message):
                     info['name'], info['realm'], region.upper(), info['ilvl']),
                 inline=True)
             msg.add_field(
-                name='Keystone Achievements (Season 1)',
+                name='Keystone Achievements (Season 2)',
                 value='**`Conqueror (+10)`:** `%s`\n**`Master (+15)`:** `%s` \n' % (
                     info['keystone_season_conqueror'], info['keystone_season_master']),
                 inline=True)
@@ -105,6 +105,14 @@ async def on_message(message):
                     info['uldir']['heroic'], info['uldir']['bosses'],
                     info['uldir']['mythic'], info['uldir']['bosses'],
                     ud_feat),
+                inline=True)
+            msg.add_field(
+                name="Battle of Dazar'alor",
+                value='**`Normal`:** `%s/%s`\n**`Heroic`:** `%s/%s`\n**`Mythic`:** `%s/%s`\n%s' % (
+                    info['battle_of_dazaralor']['normal'], info['battle_of_dazaralor']['bosses'],
+                    info['battle_of_dazaralor']['heroic'], info['battle_of_dazaralor']['bosses'],
+                    info['battle_of_dazaralor']['mythic'], info['battle_of_dazaralor']['bosses'],
+                    bod_feat),
                 inline=True)
 
             await client.send_message(message.channel, embed=msg)

--- a/constants.py
+++ b/constants.py
@@ -4,12 +4,14 @@
 """Dictionary of constants used throughout the application."""
 
 # Mythic Keystone Achievement Constants
-AC_SEASON_KEYSTONE_CONQUEROR = 13079
-AC_SEASON_KEYSTONE_MASTER = 13080
+AC_SEASON_KEYSTONE_CONQUEROR = 13448
+AC_SEASON_KEYSTONE_MASTER = 13449
 
 # Raid Achievement Constants
 AC_AOTC_UD = 12536
 AC_CE_UD = 12535
+AC_AOTC_BOD = 13322
+AC_CE_BOD = 13323
 
 # PVP Achievement Constants
 AC_ARENA_CHALLENGER = 2090
@@ -33,6 +35,7 @@ AC_SERGEANT_MAJOR_NAME = 'Sergeant Major'
 
 # Raid Constants
 RAID_UD = 9389
+RAID_BOD = 10076
 
 # Faction Constants
 FACTION_HORDE = 1

--- a/tests.py
+++ b/tests.py
@@ -120,15 +120,15 @@ class BaseTest(unittest.TestCase):
         self.maxDiff = None
         input_data_horde_sample = {
             "achievements": {
-                "achievementsCompleted": [11611, 11162, 11185, 11184, 2090, 2093,
-                    2092, 2091, 11194, 11581, 11195, 11874, 5356, 5353, 5349, 11191, 11192, 11874, 12110, 12111, 12536, 12535, 13079]
+                "achievementsCompleted": [11611, 11162, 11185, 11184, 2090, 2093, 2092, 2091, 11194, 11581, 11195, 11874, 
+                5356, 5353, 5349, 11191, 11192, 11874, 12110, 12111, 12536, 12535, 13079, 13448, 13322, 13323]
             }
         }
 
         input_data_alliance_sample = {
             "achievements": {
-                "achievementsCompleted": [11611, 11162, 11185, 11184, 2090, 2093,
-                    2092, 2091, 11194, 11581, 11195, 11874, 5343, 5339, 5334, 11192, 11874, 11875, 12110, 12536, 13079, 13080]
+                "achievementsCompleted": [11611, 11162, 11185, 11184, 2090, 2093,2092, 2091, 11194, 11581, 11195, 11874, 
+                5343, 5339, 5334, 11192, 11874, 11875, 12110, 12536, 13079, 13080, 13448, 13449, 13322]
             }
         }
 
@@ -145,7 +145,8 @@ class BaseTest(unittest.TestCase):
             'rbg_2400': 'Completed',
             'rbg_2000': 'Completed',
             'rbg_1500': 'Completed',
-            'ud_feat': 'Cutting Edge'
+            'ud_feat': 'Cutting Edge',
+            'bod_feat': 'Cutting Edge'
         }
 
         expected_alliance_data = {
@@ -161,7 +162,8 @@ class BaseTest(unittest.TestCase):
             'rbg_2400': 'Completed',
             'rbg_2000': 'Completed',
             'rbg_1500': 'Completed',
-            'ud_feat': 'Ahead of the Curve'
+            'ud_feat': 'Ahead of the Curve',
+            'bod_feat': 'Ahead of the Curve'
         }
 
         self.assertEqual(character_achievements(input_data_horde_sample, 'Horde'), expected_horde_data)
@@ -201,6 +203,7 @@ class BaseTest(unittest.TestCase):
 
         self.assertEqual(character_arena_progress(sample_data), expected_data)
 
+
     def test_pve_progression(self):
         # Passes in some mock API data and expects it to return an object with the correct data.
         # Tests for accuracy on each data check, not API data.
@@ -222,18 +225,47 @@ class BaseTest(unittest.TestCase):
                         "heroicKills": 3,
                         "mythicKills": 2,
                         }]
-                    }]
+                    },
+                    {
+                    "id": 10076,
+                    "bosses": [{
+                        "lfrKills": 19,
+                        "normalKills": 8,
+                        "heroicKills": 5,
+                        "mythicKills": 3,
+                        },
+                        {
+                        "lfrKills": 3,
+                        "normalKills": 7,
+                        "heroicKills": 3,
+                        "mythicKills": 2,
+                        },
+                        {
+                        "lfrKills": 3,
+                        "normalKills": 7,
+                        "heroicKills": 3,
+                        "mythicKills": 0,
+                        }]
+                    },
+                    ]
                 }
             }
 
         expected_data = {
-            'uldir':{
+            'uldir': {
                 'lfr':2,
                 'normal':2,
                 'heroic':2,
                 'mythic':2,
                 'bosses':2
-                }
+            },
+            'battle_of_dazaralor': {
+                'lfr':3,
+                'normal':3,
+                'heroic':3,
+                'mythic':2,
+                'bosses':3
+            }
         }
 
         self.assertEqual(character_progression(sample_data), expected_data)

--- a/wow.py
+++ b/wow.py
@@ -84,6 +84,7 @@ def character_achievements(achievement_data, faction):
     rbg_2000 = 'In Progress'
     rbg_1500 = 'In Progress'
     ud_feat = ''
+    bod_feat = ''
 
     if AC_SEASON_KEYSTONE_MASTER in achievements['achievementsCompleted']:
         keystone_season_master = 'Completed'
@@ -109,6 +110,12 @@ def character_achievements(achievement_data, faction):
         # Checks to see if the user has completed tier 2 of the AOTC achievement.
         if AC_CE_UD in achievements['achievementsCompleted']:
             ud_feat = 'Cutting Edge'
+
+    if AC_AOTC_BOD in achievements['achievementsCompleted']:
+        bod_feat = 'Ahead of the Curve'
+
+        if AC_CE_BOD in achievements['achievementsCompleted']:
+            bod_feat = 'Cutting Edge'
 
 
     # RBG achievements have a different id/name based on faction, checks these
@@ -155,6 +162,7 @@ def character_achievements(achievement_data, faction):
         'rbg_2000': rbg_2000,
         'rbg_1500': rbg_1500,
         'ud_feat': ud_feat,
+        'bod_feat': bod_feat
     }
 
     return achievement_list
@@ -208,8 +216,12 @@ def character_progression(progression_data):
         if raid['id'] == RAID_UD:
             uldir = calculate_boss_kills(raid)
 
+        if raid['id'] == RAID_BOD:
+            battle_of_dazaralor = calculate_boss_kills(raid)
+
     raid_stats = {
-        'uldir': uldir
+        'uldir': uldir,
+        'battle_of_dazaralor': battle_of_dazaralor
     }
 
     return raid_stats
@@ -391,7 +403,9 @@ async def character_info(name, realm, query, region):
                     'keystone_season_master': achievements['keystone_season_master'],
                     'keystone_season_conqueror': achievements['keystone_season_conqueror'],
                     'ud_feat': achievements['ud_feat'],
-                    'uldir': progression['uldir']
+                    'uldir': progression['uldir'],
+                    'bod_feat': achievements['bod_feat'],
+                    'battle_of_dazaralor': progression['battle_of_dazaralor']
                 }
 
                 return pve_character_sheet


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

Introduces the Battle of Dazar'alor raid data which is pending release. Also switches out the Mythic+ achievements to use the Season Two ids instead of Season One.

[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/fGANQad7Q1U/0.jpg)](https://www.youtube.com/watch?v=fGANQad7Q1U)

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

This can only be tested once the raid releases, this is because the bot is dependent on the Blizzard API.

* Run the bot once the raid releases using the configuration guide in the readme, and run `python app.py` when using this branch. 
* The output when typing `!armory pve jimo burning-legion` should contain all of the raid data for BOD, and also include the Mythic+ keystone achievement data for Season Two.

**Additional Notes**
> Anything else that will help us test the pull request.

I'd like to update this in the future so these updates are a little bit more dynamic, the idea of waiting for the next raid release isn't ideal.
